### PR TITLE
BAEL-11: Added @GeneratedValue annotation to Book model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# Intellij Idea
+/.idea
+/*.iml

--- a/src/main/java/com/baeldung/model/Book.java
+++ b/src/main/java/com/baeldung/model/Book.java
@@ -2,6 +2,7 @@ package com.baeldung.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -12,6 +13,7 @@ public class Book {
 
     @JsonIgnore
     @Id
+    @GeneratedValue
     private long id;
 
     @Column(nullable = false)


### PR DESCRIPTION
Hi,

the book model previously doesn't generate an _Id_. But this is necessary, if you want to store new books. 
This _PR_ is related to the _PR_ **BAEL-11** at the tutorials repository.

Regards,
Christian
